### PR TITLE
move closed issues to completed

### DIFF
--- a/.github/workflows/move-closed-to-completed.yml
+++ b/.github/workflows/move-closed-to-completed.yml
@@ -1,0 +1,20 @@
+name: Move closed issues to completed
+on:
+  issues:
+    types:
+      - closed
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Completed"]
+            })


### PR DESCRIPTION
helping @dannac2 :)
adding a gh action to move closed issues into "Completed" column (add the "Completed" label to them)